### PR TITLE
feat: return empty object if string is empty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export default function destr (val: any): any {
   if (typeof val !== 'string') {
     return val
   }
+  if(val === '') { return {} }
 
   const _lval = val.toLowerCase()
   if (_lval === 'true') { return true }


### PR DESCRIPTION
Without the special handling it doesn't pass this check
```
if (!JsonSigRx.test(val)) {
    return val
}
```
and thus returns an empty string again.