### PR TITLE
fix: only purge `constructor.prototype` keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,18 @@ const suspectConstructorRx = /"(?:c|\\u0063)(?:o|\\u006[Ff])(?:n|\\u006[Ee])(?:s
 const JsonSigRx = /^["[{]|^-?\d[\d.]{0,14}$/;
 
 function jsonParseTransform (key: string, value: any): any {
-  if (key === "__proto__" || key === "constructor") {
+  if (key === "__proto__") {
+    return;
+  }
+  if (key === "constructor") {
+    if (typeof value !== "object") {
+      return value;
+    }
+    const hasPrototype = Object.prototype.hasOwnProperty.call(value, "prototype");
+    if (!hasPrototype) {
+      return value;
+    }
+    // Has possible malicious prototype
     return;
   }
   return value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ function jsonParseTransform (key: string, value: any): any {
     if (typeof value !== "object") {
       return value;
     }
-    const hasPrototype = Object.prototype.hasOwnProperty.call(value, "prototype");
+    const hasPrototype = value && "prototype" in value;
     if (!hasPrototype) {
       return value;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,14 +9,7 @@ function jsonParseTransform (key: string, value: any): any {
   if (key === "__proto__") {
     return;
   }
-  if (key === "constructor") {
-    if (typeof value !== "object") {
-      return value;
-    }
-    const hasPrototype = value && "prototype" in value;
-    if (!hasPrototype) {
-      return value;
-    }
+  if (key === "constructor" && value && typeof value === "object" && ("prototype" in value)) {
     // Has possible malicious prototype
     return;
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -58,6 +58,7 @@ describe("destr", () => {
       { input: "[]", output: [] },
       { input: "{ \"key\": \"value\" }", output: { key: "value" } },
       { input: "{ \"constructor\": \"value\" }", output: { constructor: "value" } },
+      // eslint-disable-next-line unicorn/no-null
       { input: '{ "constructor": null }', output: { constructor: null } },
       { input: "[1,2,3]", output: [1, 2, 3] }
     ];

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -57,6 +57,7 @@ describe("destr", () => {
       { input: "{}", output: {} },
       { input: "[]", output: [] },
       { input: "{ \"key\": \"value\" }", output: { key: "value" } },
+      { input: "{ \"constructor\": \"value\" }", output: { constructor: "value" } },
       { input: "[1,2,3]", output: [1, 2, 3] }
     ];
 
@@ -68,7 +69,7 @@ describe("destr", () => {
   it("prevents prototype pollution", () => {
     const testCases = [
       { input: '{ "__proto__": {} }', output: {} },
-      { input: '{ "constructor": {} }', output: {} }
+      { input: '{ "constructor": { "prototype": {} } }', output: {} }
     ];
 
     for (const testCase of testCases) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -72,7 +72,6 @@ describe("destr", () => {
       { input: '{ "__proto__": {} }', output: {} },
       { input: '{ "constructor": { "prototype": {} } }', output: {} },
       { input: '{ "constructor": { "prototype": null } }', output: {} }
-      // { input: '{ "constructor": { "prototype": undefined } }', output: {} }
     ];
 
     for (const testCase of testCases) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -58,6 +58,7 @@ describe("destr", () => {
       { input: "[]", output: [] },
       { input: "{ \"key\": \"value\" }", output: { key: "value" } },
       { input: "{ \"constructor\": \"value\" }", output: { constructor: "value" } },
+      { input: '{ "constructor": null }', output: { constructor: null } },
       { input: "[1,2,3]", output: [1, 2, 3] }
     ];
 
@@ -69,7 +70,9 @@ describe("destr", () => {
   it("prevents prototype pollution", () => {
     const testCases = [
       { input: '{ "__proto__": {} }', output: {} },
-      { input: '{ "constructor": { "prototype": {} } }', output: {} }
+      { input: '{ "constructor": { "prototype": {} } }', output: {} },
+      { input: '{ "constructor": { "prototype": null } }', output: {} }
+      // { input: '{ "constructor": { "prototype": undefined } }', output: {} }
     ];
 
     for (const testCase of testCases) {


### PR DESCRIPTION
Resolves #24, resolves https://github.com/unjs/ofetch/issues/180, resolves https://github.com/nuxt/framework/issues/9468

Would really like to wait for #23 and add some tests for it too