### PR TITLE
refactor!: use named `destr` export

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,30 @@ A faster, secure and convenient alternative for [`JSON.parse`](https://developer
 Install using npm or yarn:
 
 ```bash
+# npm
 npm i destr
-# or
+
+# yarn
 yarn add destr
+
+# pnpm
+pnpm i destr
 ```
 
 Import into your Node.js project:
 
 ```js
 // CommonJS
-const destr = require("destr");
+const { destr } = require("destr");
 
 // ESM
-import destr from "destr";
+import { destr } from "destr";
 ```
 
 ### Deno
 
 ```js
-import destr from "https://deno.land/x/destr/src/index.ts";
+import { destr } from "https://deno.land/x/destr/src/index.ts";
 
 console.log(destr('{ "deno": "yay" }'));
 ```

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -1,0 +1,6 @@
+const { destr } = require("../dist/index.cjs");
+
+// Allow mixed default and named exports
+destr.destr = destr;
+
+module.exports = destr;

--- a/package.json
+++ b/package.json
@@ -9,14 +9,15 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./lib/index.cjs"
     }
   },
-  "main": "./dist/index.cjs",
+  "main": "./lib/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "lib"
   ],
   "scripts": {
     "bench": "pnpm build && node ./bench.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,10 +29,7 @@ export type Options = {
   strict?: boolean;
 };
 
-export default function destr<T = unknown>(
-  value: any,
-  options: Options = {}
-): T {
+export function destr<T = unknown>(value: any, options: Options = {}): T {
   if (typeof value !== "string") {
     return value;
   }
@@ -80,3 +77,5 @@ export default function destr<T = unknown>(
     return value as T;
   }
 }
+
+export default destr;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe, vi } from "vitest";
-import destr from "../src";
+import { destr } from "../src";
 
 describe("destr", () => {
   it("returns the passed value if it's not a string", () => {


### PR DESCRIPTION
This PR changes default export of `destr` to named export:

```diff
-- import destr from 'destr'
++ import { destr } from 'destr'

-- const destr = require('destr')
++ const { destr } = require('destr')
```

The implementation uses backward compatible CJS reexports so usually there shouldn't be breaking changes but still will be only applied in destr v2.

This change is necessary to introduce more named exports without future conflicts.