### PR TITLE
feat: support `safeDestr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ Import into your Node.js project:
 
 ```js
 // CommonJS
-const { destr } = require("destr");
+const { destr, destrSafe } = require("destr");
 
 // ESM
-import { destr } from "destr";
+import { destr, destrSafe } from "destr";
 ```
 
 ### Deno
 
 ```js
-import { destr } from "https://deno.land/x/destr/src/index.ts";
+import { destr, destrSafe } from "https://deno.land/x/destr/src/index.ts";
 
 console.log(destr('{ "deno": "yay" }'));
 ```
@@ -98,14 +98,14 @@ destr(input);
 
 ### Strict Mode
 
-If `{ strict: true }` passed as second argument, `destr` will throw an error if the input is not a valid JSON string or parsing fails. (non string values and built-ins will be still returned as-is)
+When using `destrSafe` it will throw an error if the input is not a valid JSON string or parsing fails. (non string values and built-ins will be still returned as-is)
 
 ```js
 // Returns "[foo"
-destr("[foo");
+destrSafe("[foo");
 
 // Throws an error
-destr("[foo", { strict: true });
+destrSafe("[foo", { strict: true });
 ```
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ Import into your Node.js project:
 
 ```js
 // CommonJS
-const { destr, destrSafe } = require("destr");
+const { destr, safeDestr } = require("destr");
 
 // ESM
-import { destr, destrSafe } from "destr";
+import { destr, safeDestr } from "destr";
 ```
 
 ### Deno
 
 ```js
-import { destr, destrSafe } from "https://deno.land/x/destr/src/index.ts";
+import { destr, safeDestr } from "https://deno.land/x/destr/src/index.ts";
 
 console.log(destr('{ "deno": "yay" }'));
 ```
@@ -98,14 +98,14 @@ destr(input);
 
 ### Strict Mode
 
-When using `destrSafe` it will throw an error if the input is not a valid JSON string or parsing fails. (non string values and built-ins will be still returned as-is)
+When using `safeDestr` it will throw an error if the input is not a valid JSON string or parsing fails. (non string values and built-ins will be still returned as-is)
 
 ```js
 // Returns "[foo"
-destrSafe("[foo");
+safeDestr("[foo");
 
 // Throws an error
-destrSafe("[foo", { strict: true });
+safeDestr("[foo", { strict: true });
 ```
 
 ## Benchmarks

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -1,7 +1,7 @@
-const { destr, destrSafe } = require("../dist/index.cjs");
+const { destr, safeDestr } = require("../dist/index.cjs");
 
 // Allow mixed default and named exports
 destr.destr = destr;
-destr.destrSafe = destrSafe;
+destr.safeDestr = safeDestr;
 
 module.exports = destr;

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -1,6 +1,7 @@
-const { destr } = require("../dist/index.cjs");
+const { destr, destrSafe } = require("../dist/index.cjs");
 
 // Allow mixed default and named exports
 destr.destr = destr;
+destr.destrSafe = destrSafe;
 
 module.exports = destr;

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export function destr<T = unknown>(value: any, options: Options = {}): T {
   }
 }
 
-export function destrSafe<T = unknown>(value: any, options: Options = {}): T {
+export function safeDestr<T = unknown>(value: any, options: Options = {}): T {
   return destr<T>(value, { ...options, strict: true });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,13 +60,16 @@ export function destr<T = unknown>(value: any, options: Options = {}): T {
 
   if (!JsonSigRx.test(value)) {
     if (options.strict) {
-      throw new SyntaxError("Invalid JSON");
+      throw new SyntaxError("[destr] Invalid JSON");
     }
     return value as T;
   }
 
   try {
     if (suspectProtoRx.test(value) || suspectConstructorRx.test(value)) {
+      if (options.strict) {
+        throw new Error("[destr] Possible prototype pollution");
+      }
       return JSON.parse(value, jsonParseTransform);
     }
     return JSON.parse(value);
@@ -76,6 +79,10 @@ export function destr<T = unknown>(value: any, options: Options = {}): T {
     }
     return value as T;
   }
+}
+
+export function destrSafe<T = unknown>(value: any, options: Options = {}): T {
+  return destr<T>(value, { ...options, strict: true });
 }
 
 export default destr;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe, vi } from "vitest";
-import { destr, destrSafe } from "../src";
+import { destr, safeDestr } from "../src";
 
 describe("destr", () => {
   it("returns the passed value if it's not a string", () => {
@@ -121,7 +121,7 @@ describe("destr", () => {
     }
   });
 
-  it("throws an error if it's a invalid JSON texts with destrSafe", () => {
+  it("throws an error if it's a invalid JSON texts with safeDestr", () => {
     const testCases = [
       { input: "{     ", output: "Unexpected end of JSON input" },
       { input: "[     ", output: "Unexpected end of JSON input" },
@@ -131,7 +131,7 @@ describe("destr", () => {
     ];
 
     for (const testCase of testCases) {
-      expect(() => destrSafe(testCase.input)).toThrowError(
+      expect(() => safeDestr(testCase.input)).toThrowError(
         testCase.output || ""
       );
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe, vi } from "vitest";
-import { destr } from "../src";
+import { destr, destrSafe } from "../src";
 
 describe("destr", () => {
   it("returns the passed value if it's not a string", () => {
@@ -107,7 +107,7 @@ describe("destr", () => {
     }
   });
 
-  it("returns the passed string if it's a invalid JSON text and `strict` option is set `false`", () => {
+  it("returns the passed string if it's a invalid JSON text by default", () => {
     const testCases = [
       { input: "{     " },
       { input: "[     " },
@@ -121,7 +121,7 @@ describe("destr", () => {
     }
   });
 
-  it("throws an error if it's a invalid JSON texts and `strict` option is set `true`", () => {
+  it("throws an error if it's a invalid JSON texts with destrSafe", () => {
     const testCases = [
       { input: "{     ", output: "Unexpected end of JSON input" },
       { input: "[     ", output: "Unexpected end of JSON input" },
@@ -131,7 +131,7 @@ describe("destr", () => {
     ];
 
     for (const testCase of testCases) {
-      expect(() => destr(testCase.input, { strict: true })).toThrowError(
+      expect(() => destrSafe(testCase.input)).toThrowError(
         testCase.output || ""
       );
     }


### PR DESCRIPTION
`strict` option originally added in #11 by @tobiasdiez 

This PR adds a new dedicated `safeDestr` utility leveraging named export support in destr v2 for more standard usage with strict mode being enabled.

This PR also enables strict mode for possible prototype pollution to fail instead of silent ignore. (slight behavior change for v2)