### PR TITLE
docs: correct `safeDestr` example usage and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ When using `safeDestr` it will throw an error if the input is not a valid JSON s
 
 ```js
 // Returns "[foo"
-safeDestr("[foo");
+destr("[foo");
 
 // Throws an error
-safeDestr("[foo", { strict: true });
+safeDestr("[foo");
 ```
 
 ## Benchmarks

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,6 +12,7 @@ describe("destr", () => {
       /* eslint-disable-next-line unicorn/no-null */
       { input: null },
       { input: Number.POSITIVE_INFINITY },
+      { input: Number.NEGATIVE_INFINITY },
       { input: undefined },
     ];
 
@@ -47,6 +48,11 @@ describe("destr", () => {
     expect(destr("Infinity")).toStrictEqual(Number.POSITIVE_INFINITY);
   });
 
+  it("parses string '-infinity' as `Number.NEGATIVE_INFINITY` case-insensitively", () => {
+    expect(destr("-infinity")).toStrictEqual(Number.NEGATIVE_INFINITY);
+    expect(destr("-Infinity")).toStrictEqual(Number.NEGATIVE_INFINITY);
+  });
+
   it("parses string 'undefined' as `undefined` case-insensitively", () => {
     expect(destr("undefined")).toBeUndefined();
     expect(destr("UNDEFINED")).toBeUndefined();
@@ -59,7 +65,7 @@ describe("destr", () => {
   });
 
   it("parses valid JSON texts", () => {
-    const testCases = [
+    const testCases: Array<{ input: string; output: unknown }> = [
       { input: "{}", output: {} },
       { input: "[]", output: [] },
       { input: '{ "key": "value" }', output: { key: "value" } },
@@ -146,6 +152,29 @@ describe("destr", () => {
     for (const testCase of testCases) {
       expect(() => safeDestr(testCase.input)).toThrowError(
         testCase.output || ""
+      );
+    }
+  });
+
+  it("throws an error on possible prototype pollution with safeDestr", () => {
+    const testCases = [
+      {
+        input: '{ "__proto__": {} }',
+        output: {},
+      },
+      {
+        input: '{ "constructor": { "prototype": {} } }',
+        output: {},
+      },
+      {
+        input: '{ "constructor": { "prototype": null } }',
+        output: {},
+      },
+    ];
+
+    for (const testCase of testCases) {
+      expect(() => safeDestr(testCase.input)).toThrowError(
+        "[destr] Possible prototype pollution"
       );
     }
   });


### PR DESCRIPTION
I also saw some uncovered lines during `pnpm t` and fixed that for 100% coverage.