### PR TITLE
perf: avoid lowercasing long strings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,28 +40,30 @@ export function destr<T = unknown>(value: any, options: Options = {}): T {
     return _value.slice(1, -1) as T;
   }
 
-  const _lval = _value.toLowerCase();
-  if (_lval === "true") {
-    return true as T;
-  }
-  if (_lval === "false") {
-    return false as T;
-  }
-  if (_lval === "undefined") {
-    return undefined as T;
-  }
-  if (_lval === "null") {
-    // eslint-disable-next-line unicorn/no-null
-    return null as T;
-  }
-  if (_lval === "nan") {
-    return Number.NaN as T;
-  }
-  if (_lval === "infinity") {
-    return Number.POSITIVE_INFINITY as T;
-  }
-  if (_lval === "-infinity") {
-    return Number.NEGATIVE_INFINITY as T;
+  if (_value.length <= 9) {
+    const _lval = _value.toLowerCase();
+    if (_lval === "true") {
+      return true as T;
+    }
+    if (_lval === "false") {
+      return false as T;
+    }
+    if (_lval === "undefined") {
+      return undefined as T;
+    }
+    if (_lval === "null") {
+      // eslint-disable-next-line unicorn/no-null
+      return null as T;
+    }
+    if (_lval === "nan") {
+      return Number.NaN as T;
+    }
+    if (_lval === "infinity") {
+      return Number.POSITIVE_INFINITY as T;
+    }
+    if (_lval === "-infinity") {
+      return Number.NEGATIVE_INFINITY as T;
+    }
   }
 
   if (!JsonSigRx.test(value)) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#80

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If the string is longer than nine characters it cannot possibly match any of the hard-coded strings. So wrap the lowercasing operation in a conditional that prevents the operation if the string is ten characters or longer.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
