### PR TITLE
fix: prevent silent precision loss for integers beyond MAX_SAFE_INTEGER

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,22 @@ export function destr<T = unknown>(value: any, options: Options = {}): T {
       }
       return JSON.parse(value, jsonParseTransform);
     }
-    return JSON.parse(value);
+    const result = JSON.parse(value);
+    // Guard against silent precision loss for integers beyond MAX_SAFE_INTEGER.
+    // e.g. '9007199254740993' would silently become 9007199254740992.
+    if (
+      typeof result === "number" &&
+      Number.isInteger(result) &&
+      !Number.isSafeInteger(result)
+    ) {
+      if (options.strict) {
+        throw new SyntaxError(
+          `[destr] Loss of precision for large integer string: "${value}"`,
+        );
+      }
+      return value as T;
+    }
+    return result;
   } catch (error) {
     if (options.strict) {
       throw error;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -197,4 +197,24 @@ describe("destr", () => {
       expect(destr(testCase.input)).toStrictEqual(testCase.output);
     }
   });
+
+  it("returns large integer strings as-is to prevent silent precision loss (#152)", () => {
+    // Numbers beyond Number.MAX_SAFE_INTEGER cannot be reliably represented
+    // as JS floats — destr must return the original string to avoid corruption.
+    const testCases = [
+      "9007199254740992", // MAX_SAFE_INTEGER + 1 (2^53)
+      "9007199254740993", // exact value from issue report → would silently become 9007199254740992
+      "-9007199254740993",
+    ];
+
+    for (const input of testCases) {
+      expect(destr(input)).toStrictEqual(input);
+    }
+  });
+
+  it("throws on large integer strings in strict mode (#152)", () => {
+    expect(() => safeDestr("9007199254740993")).toThrowError(
+      "[destr] Loss of precision for large integer string",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Closes #152

`destr` uses `JSON.parse` to convert numeric-looking strings to numbers. When a string represents an integer larger than `Number.MAX_SAFE_INTEGER`, `JSON.parse` silently loses precision:

```ts
destr('9007199254740993') // → 9007199254740992  ❌ (silent data corruption)
```

This affects large IDs, counters, and any integer-valued string coming through Nitro/Nuxt `runtimeConfig`, h3 query params, etc.

## Fix

After `JSON.parse` succeeds, if the result is a non-safe integer (`!Number.isSafeInteger(result)`), return the original string instead of the corrupted number:

```ts
// src/index.ts
const result = JSON.parse(value);
if (
  typeof result === "number" &&
  Number.isInteger(result) &&
  !Number.isSafeInteger(result)
) {
  if (options.strict) {
    throw new SyntaxError(`[destr] Loss of precision for large integer string: "${value}"`);
  }
  return value as T; // keep the string — precision cannot be guaranteed
}
return result;
```

- Safe integers (`<= Number.MAX_SAFE_INTEGER`) continue to parse as numbers — no behaviour change.
- `safeDestr` throws a descriptive `SyntaxError` for large integers rather than silently corrupting.

## Tests

Two new test cases added to `test/index.test.ts`:
- `destr` returns the original string for `9007199254740992`, `9007199254740993`, `-9007199254740993`
- `safeDestr` throws `"[destr] Loss of precision for large integer string"` in strict mode

All 24 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large integer values during parsing to prevent silent precision loss
  * In strict mode, invalid integer values now raise an error; otherwise returns the original string value

<!-- end of auto-generated comment: release notes by coderabbit.ai -->