### PR TITLE
feat: support reviver parameter and fix precision parsing for huge numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,21 +5,7 @@ const suspectProtoRx =
 const suspectConstructorRx =
   /"(?:c|\\u0063)(?:o|\\u006[Ff])(?:n|\\u006[Ee])(?:s|\\u0073)(?:t|\\u0074)(?:r|\\u0072)(?:u|\\u0075)(?:c|\\u0063)(?:t|\\u0074)(?:o|\\u006[Ff])(?:r|\\u0072)"\s*:/;
 
-const JsonSigRx = /^\s*["[{]|^\s*-?\d{1,16}(\.\d{1,17})?([Ee][+-]?\d+)?\s*$/;
-
-function jsonParseTransform(key: string, value: any): any {
-  if (
-    key === "__proto__" ||
-    (key === "constructor" &&
-      value &&
-      typeof value === "object" &&
-      "prototype" in value)
-  ) {
-    warnKeyDropped(key);
-    return;
-  }
-  return value;
-}
+const JsonSigRx = /^\s*["[{]|^\s*-?\d+(\.\d+)?([Ee][+-]?\d+)?\s*$/;
 
 function warnKeyDropped(key: string): void {
   console.warn(`[destr] Dropping "${key}" key to prevent prototype pollution.`);
@@ -27,12 +13,22 @@ function warnKeyDropped(key: string): void {
 
 export type Options = {
   strict?: boolean;
+  reviver?: (this: any, key: string, value: any) => any;
 };
 
-export function destr<T = unknown>(value: any, options: Options = {}): T {
+export function destr<T = unknown>(
+  value: any,
+  optionsOrReviver?: Options | ((this: any, key: string, value: any) => any),
+): T {
   if (typeof value !== "string") {
     return value;
   }
+
+  const options =
+    typeof optionsOrReviver === "function"
+      ? { reviver: optionsOrReviver }
+      : optionsOrReviver || {};
+
   if (
     value[0] === '"' &&
     value[value.length - 1] === '"' &&
@@ -81,9 +77,24 @@ export function destr<T = unknown>(value: any, options: Options = {}): T {
       if (options.strict) {
         throw new Error("[destr] Possible prototype pollution");
       }
-      return JSON.parse(value, jsonParseTransform);
+      return JSON.parse(value, (key, val) => {
+        if (
+          key === "__proto__" ||
+          (key === "constructor" &&
+            val &&
+            typeof val === "object" &&
+            "prototype" in val)
+        ) {
+          warnKeyDropped(key);
+          return;
+        }
+        if (options.reviver) {
+          return options.reviver(key, val);
+        }
+        return val;
+      });
     }
-    return JSON.parse(value);
+    return JSON.parse(value, options.reviver);
   } catch (error) {
     if (options.strict) {
       throw error;
@@ -92,7 +103,14 @@ export function destr<T = unknown>(value: any, options: Options = {}): T {
   }
 }
 
-export function safeDestr<T = unknown>(value: any, options: Options = {}): T {
+export function safeDestr<T = unknown>(
+  value: any,
+  optionsOrReviver?: Options | ((this: any, key: string, value: any) => any),
+): T {
+  const options =
+    typeof optionsOrReviver === "function"
+      ? { reviver: optionsOrReviver }
+      : optionsOrReviver || {};
   return destr<T>(value, { ...options, strict: true });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export function destr<T = unknown>(
       if (options.strict) {
         throw new Error("[destr] Possible prototype pollution");
       }
-      return JSON.parse(value, (key, val) => {
+      return JSON.parse(value, function (this: any, key, val) {
         if (
           key === "__proto__" ||
           (key === "constructor" &&
@@ -89,7 +89,7 @@ export function destr<T = unknown>(
           return;
         }
         if (options.reviver) {
-          return options.reviver(key, val);
+          return options.reviver.call(this, key, val);
         }
         return val;
       });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -200,10 +200,13 @@ describe("destr", () => {
 
   it("parses huge numbers without throwing in safeDestr", () => {
     const hugeNumber = "123456789012345678901234567890";
+    const expected = JSON.parse(hugeNumber);
     // 默认模式下应该解析为数字类型（即便有精度损失，也应符合原生 JSON.parse 行为）
     expect(typeof destr(hugeNumber)).toBe("number");
+    expect(destr(hugeNumber)).toBe(expected);
     // 严格模式下不应抛出 "Invalid JSON" 错误
     expect(typeof safeDestr(hugeNumber)).toBe("number");
+    expect(safeDestr(hugeNumber)).toBe(expected);
   });
 
   describe("reviver support", () => {
@@ -224,6 +227,7 @@ describe("destr", () => {
         return value;
       };
       expect(destr(input, reviver)).toStrictEqual({ a: 10, b: 2 });
+      expect(safeDestr(input, reviver)).toStrictEqual({ a: 10, b: 2 });
     });
 
     it("chains reviver with prototype pollution filter", () => {
@@ -236,6 +240,34 @@ describe("destr", () => {
       // __proto__ 键应该在到达用户指定的 reviver 前被过滤，因此不应触发 reviver
       expect(reviver).not.toHaveBeenCalledWith("__proto__", expect.any(Object));
       expect(reviver).toHaveBeenCalledWith("a", 1);
+    });
+
+    it("preserves correct `this` binding in reviver", () => {
+      const input = '{"a": 1, "b": {"c": 2}}';
+      const thisValues: any[] = [];
+      const reviver = function (this: any, key: string, value: any) {
+        if (key === "c") {
+          thisValues.push(this);
+        }
+        return value;
+      };
+      destr(input, { reviver });
+      expect(thisValues.length).toBe(1);
+      expect(thisValues[0]).toHaveProperty("c", 2);
+    });
+
+    it("preserves correct `this` binding in prototype pollution safe mode", () => {
+      const input = '{"__proto__": {}, "a": 1, "b": {"c": 2}}';
+      const thisValues: any[] = [];
+      const reviver = function (this: any, key: string, value: any) {
+        if (key === "c") {
+          thisValues.push(this);
+        }
+        return value;
+      };
+      destr(input, { reviver });
+      expect(thisValues.length).toBe(1);
+      expect(thisValues[0]).toHaveProperty("c", 2);
     });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -197,4 +197,45 @@ describe("destr", () => {
       expect(destr(testCase.input)).toStrictEqual(testCase.output);
     }
   });
+
+  it("parses huge numbers without throwing in safeDestr", () => {
+    const hugeNumber = "123456789012345678901234567890";
+    // 默认模式下应该解析为数字类型（即便有精度损失，也应符合原生 JSON.parse 行为）
+    expect(typeof destr(hugeNumber)).toBe("number");
+    // 严格模式下不应抛出 "Invalid JSON" 错误
+    expect(typeof safeDestr(hugeNumber)).toBe("number");
+  });
+
+  describe("reviver support", () => {
+    it("supports reviver as an option", () => {
+      const input = '{"a": 1, "b": 2}';
+      const reviver = (key: string, value: any) => {
+        if (key === "a") return value * 10;
+        return value;
+      };
+      expect(destr(input, { reviver })).toStrictEqual({ a: 10, b: 2 });
+      expect(safeDestr(input, { reviver })).toStrictEqual({ a: 10, b: 2 });
+    });
+
+    it("supports reviver as the second argument directly", () => {
+      const input = '{"a": 1, "b": 2}';
+      const reviver = (key: string, value: any) => {
+        if (key === "a") return value * 10;
+        return value;
+      };
+      expect(destr(input, reviver)).toStrictEqual({ a: 10, b: 2 });
+    });
+
+    it("chains reviver with prototype pollution filter", () => {
+      const input = '{"a": 1, "__proto__": {"polluted": true}}';
+      const reviver = vi.fn((key: string, value: any) => value);
+
+      const result = destr(input, { reviver });
+
+      expect(result).toStrictEqual({ a: 1 });
+      // __proto__ 键应该在到达用户指定的 reviver 前被过滤，因此不应触发 reviver
+      expect(reviver).not.toHaveBeenCalledWith("__proto__", expect.any(Object));
+      expect(reviver).toHaveBeenCalledWith("a", 1);
+    });
+  });
 });


### PR DESCRIPTION
### 📝 Description

This PR brings two significant enhancements and bug fixes to `destr`, ensuring better parity with native `JSON.parse` and improving robustness when parsing huge numbers.

#### 1. Support for `reviver` Parameter (`JSON.parse` parity)
- **Feature**: Extends the signatures of `destr` and `safeDestr` to accept a custom `reviver` function, either nested in the `options` object or passed directly as the second argument (seamless drop-in replacement for native `JSON.parse(text, reviver)`).
- **Security-First Chaining**: When a prototype-pollution signature is detected, the pollution filter drops the unsafe keys (`__proto__`, `constructor`) first, and safely chains the remaining sanitized keys into the user's custom `reviver`. On normal paths, it directly utilizes native `JSON.parse(value, reviver)` for optimal performance.

#### 2. Fix for Huge Numbers Being Treated as Invalid JSON
- **Bug**: The internal `JsonSigRx` regular expression was hardcoded to expect digits with max length 16 (`\d{1,16}`). This caused long numeric strings (e.g., `"123456789012345678901234567890"`) to fail validation. It fell back to returning raw strings in default mode, and incorrectly threw `SyntaxError: [destr] Invalid JSON` in strict (`safeDestr`) mode.
- **Fix**: Relaxed the rigid digit-length limits in `JsonSigRx` since native `JSON.parse` handles numeric parsing natively (even with IEEE 754 precision rounding), bringing full compliance to specification behaviors without losing error safety.

---

### 🧪 Tests & Verification

- Added new robust unit tests in `test/index.test.ts` covering:
  - Big numbers parsing in both `destr` and `safeDestr`.
  - `reviver` options payload parsing.
  - Direct `reviver` argument parsing.
  - Correct execution order between prototype-pollution prevention filter and custom `reviver` callbacks.
- All 26 unit tests passed successfully:
  ```bash
  ✓ test/index.test.ts (26 tests) 13ms
  ```
- Code formatted and lint-checked via `npm run lint`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional reviver callback for custom transformation of JSON values during parsing
  * API now accepts a reviver function as an alternative to the options object

* **Bug Fixes**
  * Improved prototype-pollution protection to filter dangerous properties during parse

* **Tests**
  * Expanded tests for reviver behavior, very large numeric strings, and security protections
<!-- end of auto-generated comment: release notes by coderabbit.ai -->