### PR TITLE
docs: fix Deno import example for named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,14 @@ const { destr, safeDestr } = require("destr");
 ### Deno
 
 ```js
-import { destr, safeDestr } from "https://deno.land/x/destr/src/index.ts";
+import { destr, safeDestr } from "npm:destr";
+// or
+import { destr, safeDestr } from "https://unpkg.com/destr/dist/index.mjs";
 
 console.log(destr('{ "deno": "yay" }'));
 ```
+
+> **Note:** `https://deno.land/x/destr` currently resolves to v1.0.0, which only provides a default export. Use `npm:destr` or the unpkg URL above for v2 named exports.
 
 ## Why?
 

--- a/deno.ts
+++ b/deno.ts
@@ -1,4 +1,4 @@
 #!deno run
-import destr from "https://deno.land/x/destr/src/index.ts";
+import { destr } from "npm:destr";
 
-console.log(destr("{ \"deno\": \"yay\" }"));
+console.log(destr('{ "deno": "yay" }'));


### PR DESCRIPTION
## Summary

- Update Deno docs to use `npm:destr` and unpkg dist URL instead of `deno.land/x/destr/src/index.ts`
- Align `deno.ts` example with the documented import
- Add note that `deno.land/x/destr` still resolves to v1.0.0 (default export only)

## Example

```js
import { destr, safeDestr } from "npm:destr";

console.log(destr('{ "deno": "yay" }')); // { deno: "yay" }
```

Fixes #138

## Test plan

- [x] Verified `unpkg.com/destr/dist/index.mjs` exports named `destr` and `safeDestr`
- [x] Confirmed `deno.land/x/destr` redirects to v1.0.0 (no named exports)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Deno usage instructions to recommend importing via `npm:destr` or unpkg ESM URL.
  * Added compatibility note regarding `deno.land/x/destr` version and export format.

* **Chores**
  * Updated example Deno script to use recommended import method.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/destr/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->