### PR TITLE
fix: do not treat a lone double-quote as an empty string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export function destr<T = unknown>(value: any, options: Options = {}): T {
     return value;
   }
   if (
+    value.length > 1 &&
     value[0] === '"' &&
     value[value.length - 1] === '"' &&
     value.indexOf("\\") === -1

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -138,6 +138,12 @@ describe("destr", () => {
     }
   });
 
+  it("does not treat a lone double-quote as an empty string", () => {
+    // A single `"` is invalid JSON (JSON.parse('"') throws). The fast path
+    // must not collapse it to "" by slicing the same char as start and end.
+    expect(destr('"')).toStrictEqual('"');
+  });
+
   describe("throws an error if it's a invalid JSON texts with safeDestr", () => {
     const testCases = [
       { input: "{     ", output: "Expected property name or" },
@@ -146,6 +152,7 @@ describe("destr", () => {
       { input: "[1,2,3]?", output: "Unexpected non-whitespace character" },
       { input: "invalid JSON text", output: "Invalid JSON" },
       { input: ' "Invalid', output: "Unterminated string in JSON at position" },
+      { input: '"', output: "Unterminated string in JSON at position" },
     ];
 
     for (const testCase of testCases) {


### PR DESCRIPTION
The fast path for double-quoted strings collapses a lone `"` into an empty string.

When the input is a single `"`, `value[0]` and `value[value.length - 1]` are the same character, so the fast-path condition passes and `value.slice(1, -1)` returns `""`. That is wrong: a single `"` is not valid JSON.

```js
import { destr, safeDestr } from "destr";

destr('"');     // ""   (expected: '"', the raw string, since it is not valid JSON)
safeDestr('"'); // ""   (expected: throws, per the strict-mode contract)

JSON.parse('"'); // SyntaxError: Unterminated string in JSON
```

The `safeDestr` case is the real problem. The README says strict mode "will throw an error if the input is not a valid JSON string or parsing fails", but here it silently returns `""` because the fast path bypasses JSON parsing entirely before strict mode is ever consulted.

The fix adds a `value.length > 1` guard so a single `"` falls through to the normal path. There it is treated as invalid JSON: `destr` returns the raw string by default, and `safeDestr` throws (matching `JSON.parse`).

Tests added:
- `destr('"')` returns `'"'` instead of `""`.
- `safeDestr('"')` throws `Unterminated string in JSON at position`, alongside the existing invalid-input cases.

Both fail on `main` and pass with this change. Full suite, eslint and prettier are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where single-character quoted strings were not being properly processed during deserialization, ensuring accurate handling of edge cases.

* **Tests**
  * Added test cases for single-character string inputs and enhanced error handling validation to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->