### PR TITLE
docs: clarify type parameter does not validate at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,22 @@ console.log(destr('{ "deno": "yay" }'));
 
 ## Why?
 
-### ✅ Type Safe
+### ✅ Better Type Safety
 
 ```ts
 const obj = JSON.parse("{}"); // obj type is any
 
 const obj = destr("{}"); // obj type is unknown by default
 
-const obj = destr<MyInterface>("{}"); // obj is well-typed
+const obj = destr<MyInterface>("{}"); // obj is typed as MyInterface
 ```
+
+`destr` returns `unknown` by default instead of `any`, so you have to narrow the
+value before using it. Passing a type parameter (`destr<MyInterface>(...)`) only
+casts the result for the type checker; it does **not** validate the parsed value
+at runtime. If you need runtime validation, pass the output through a schema
+parser such as [zod](https://zod.dev), [valibot](https://valibot.dev) or
+[arktype](https://arktype.io).
 
 ### ✅ Fast fallback to input if is not string
 


### PR DESCRIPTION
## Summary

Closes #168.

The README's "Type Safe" section can be misread as suggesting that `destr<MyInterface>("...")` validates the parsed value against the supplied type. It does not — the type parameter only casts the result for the type checker, and no runtime validation happens.

This PR keeps the (accurate) `any` vs `unknown` point and:

- Renames the heading from **Type Safe** to **Better Type Safety**, which is less likely to be read as a validation guarantee.
- Adds a short note explaining that the type parameter is a compile-time cast only, and points to schema parsers (zod, valibot, arktype) for actual runtime validation.

## Changes

- `README.md` — reworded the "Why?" type-safety section and updated the inline comment on the `destr<MyInterface>` example.

## Notes

Docs-only change. The repo's `lint`/`test` scripts target `src` and `test` only, so no build or test behavior is affected. Wrapping matches the surrounding README style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s type-safety guidance with clearer TypeScript examples.
  * Clarified that `destr` returns `unknown` by default, and that type parameters do not provide runtime validation.
  * Added guidance that runtime validation should be handled with a schema parser such as zod, valibot, or arktype.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->