### PR TITLE
docs: compare parsing and serialization tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@
 
 A faster, secure and convenient alternative for [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
 
+## Choosing the right tool
+
+These libraries overlap in places, but they do not all solve the same problem. `destr` and `fast-json-parse` are direct string-parsing alternatives; the others serialize values and parse their own output for a round trip.
+
+### String parsers
+
+| Library                                                          | Main API                            | Distinctive behavior                                                                                                         | Choose when                                                                                       |
+| ---------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [`destr`](https://github.com/unjs/destr)                         | `destr(value)` / `safeDestr(value)` | Returns invalid input unchanged by default, offers a strict mode, and filters prototype-pollution keys; no serialization API | Parsing untrusted or mixed string input with either fallback or strict failure behavior           |
+| [`fast-json-parse`](https://github.com/mcollina/fast-json-parse) | `parse(value)` → `{ value, err }`   | Legacy API that reports a parse error in the result object instead of throwing; no serialization API                         | Maintaining older code that expects this result shape; its optimization is unnecessary on Node 7+ |
+
+### Serialization round trips
+
+| Library                                                     | Main APIs                                                                       | Distinctive behavior                                                                                                          | Choose when                                                                                                  |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [`devalue`](https://github.com/sveltejs/devalue)            | `stringify(value)` ↔ `parse(text)`                                              | Preserves circular and repeated references plus rich JavaScript types; escapes markup-sensitive characters in rendered output | Serializing server-to-client application state, including server-rendered state, for a matching `parse` call |
+| [`superjson`](https://github.com/flightcontrolhq/superjson) | `stringify(value)` ↔ `parse(text)`; `serialize(value)` ↔ `deserialize(payload)` | Preserves rich JavaScript types through a JSON-compatible value and metadata envelope                                         | Transporting `Date`, `Map`, `Set`, or `BigInt` through JSON-oriented frameworks such as tRPC                 |
+| [`flatted`](https://github.com/WebReflection/flatted)       | `stringify(value)` ↔ `parse(text)`                                              | Preserves circular references while limiting values to JSON-compatible data                                                   | Serializing circular JSON data without broader rich-type handling                                            |
+
+`devalue`'s XSS mitigation applies when trusted server code serializes state for the client. Do not use its `uneval` format to accept untrusted client-to-server data.
+
 ## Usage
 
 ### Node.js


### PR DESCRIPTION
## Summary

- add a use-case comparison for `destr` and adjacent parsing or serialization libraries
- distinguish one-way parsers from serialization round trips so the tools are not presented as direct competitors
- document the legacy optimization context for `fast-json-parse`

Closes #159

## Verification

- `./node_modules/.bin/eslint .`
- `./node_modules/.bin/prettier -c src test README.md`
- `./node_modules/.bin/unbuild`
- `./node_modules/.bin/vitest run --coverage` (22 tests passed; `src/index.ts` at 100% coverage)
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Choosing the right tool” section to help users select the best library for their data pipeline needs.
  * Included comparison tables for parsing alternatives and for serialization/round-trip tools.
  * Added security and usage cautions, including guidance around XSS mitigation and avoiding unsafe approaches for untrusted data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->