### PR TITLE
docs: fix Deno import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const { destr, safeDestr } = require("destr");
 ### Deno
 
 ```js
-import { destr, safeDestr } from "https://deno.land/x/destr/src/index.ts";
+import { destr, safeDestr } from "npm:destr";
 
 console.log(destr('{ "deno": "yay" }'));
 ```

--- a/deno.ts
+++ b/deno.ts
@@ -1,4 +1,4 @@
 #!deno run
-import destr from "https://deno.land/x/destr/src/index.ts";
+import destr from "npm:destr";
 
 console.log(destr("{ \"deno\": \"yay\" }"));


### PR DESCRIPTION
## Summary

- replace the stale deno.land/x import with Deno's supported `npm:` specifier
- update both the README snippet and the checked-in `deno.ts` example

The unversioned deno.land URL currently resolves to the old v1.0.0 module, which does not expose the documented named exports. Using `npm:destr` resolves the current package and supports both named and default imports.

Fixes #138

## Validation

- `pnpm test` (22 tests passed)
- `pnpm build`
- `deno run deno.ts` → `{ deno: "yay" }`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Deno usage example to import from the npm package specifier.

* **Chores**
  * Updated the Deno script’s import path while preserving its existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->