### PR TITLE
docs: clarify Type Safe wording is not runtime validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,17 @@ console.log(destr('{ "deno": "yay" }'));
 
 ## Why?
 
-### ✅ Type Safe
+### ✅ Better type safety
 
 ```ts
 const obj = JSON.parse("{}"); // obj type is any
 
 const obj = destr("{}"); // obj type is unknown by default
 
-const obj = destr<MyInterface>("{}"); // obj is well-typed
+const obj = destr<MyInterface>("{}"); // obj is typed as MyInterface
 ```
+
+`destr` does **not** validate runtime data against the type parameter. The generic only asserts the TypeScript type. Use a schema parser (for example [Zod](https://zod.dev/) or [Valibot](https://valibot.dev/)) when you need runtime validation.
 
 ### ✅ Fast fallback to input if is not string
 


### PR DESCRIPTION
## Summary
- Rename `Type Safe` to `Better type safety`
- Clarify that the generic does not validate at runtime; point to schema parsers

Closes #168

## Test plan
- [ ] README wording matches intent of #168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated TypeScript guidance for `destr`.
  - Clarified that generic types do not provide runtime validation.
  - Recommended schema validation tools such as Zod or Valibot for runtime checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->