### PR TITLE
fix: preserve large numeric strings exceeding MAX_SAFE_INTEGER

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,15 @@ export function destr<T = unknown>(value: any, options: Options = {}): T {
       }
       return JSON.parse(value, jsonParseTransform);
     }
-    return JSON.parse(value);
+    const parsed = JSON.parse(value);
+    if (
+      typeof parsed === "number" &&
+      !Number.isSafeInteger(parsed) &&
+      /^\s*-?\d+\s*$/.test(value)
+    ) {
+      return value as T;
+    }
+    return parsed;
   } catch (error) {
     if (options.strict) {
       throw error;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -197,4 +197,10 @@ describe("destr", () => {
       expect(destr(testCase.input)).toStrictEqual(testCase.output);
     }
   });
+  it("preserves large integer strings exceeding MAX_SAFE_INTEGER as string to prevent precision loss", () => {
+    const raw = "9007199254740993";
+    expect(destr(raw)).toStrictEqual(raw);
+    expect(destr("-9007199254740993")).toStrictEqual("-9007199254740993");
+    expect(destr("9007199254740991")).toStrictEqual(9_007_199_254_740_991);
+  });
 });


### PR DESCRIPTION
<!-- Auto-closing issue -->
Resolves #152

### Summary

Preserves numeric strings exceeding `Number.MAX_SAFE_INTEGER` (or below `Number.MIN_SAFE_INTEGER`) as strings rather than coercing them into floating-point numbers with precision loss.

### Context & Cause

When parsing numeric strings (such as large IDs or timestamps in environment variables/configs), `JSON.parse()` converts values like `'9007199254740993'` into `9007199254740992`. In JavaScript, numbers above ^{53} - 1$ cannot be represented accurately as safe integers, leading to silent data and ID corruption in downstream consumers.

### Solution

After `JSON.parse(value)`, if the result is a number that is not a safe integer (`!Number.isSafeInteger(parsed)`) and the input is a pure integer string (`/^\s*-?\d+\s*$/`), destr keeps and returns the original string representation.

### Verification

- `pnpm test` passed 100% (23 tests passed, clean lint and formatting).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large integer-only values that exceed JavaScript’s safe integer range are now preserved as strings, preventing precision loss.
  * Negative large integers are handled consistently, while safe integers continue to parse as numbers.

* **Tests**
  * Added coverage for safe and unsafe positive and negative integer values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->